### PR TITLE
fix: Set logo ref as github url

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <p align="center">
     <br>
     <a href="https://github.com/jgoodman8/pyhist">
-        <img src="assets/pyhist.png" alt="PyHist Logo" width="450"/>
+        <img src="https://raw.githubusercontent.com/jgoodman8/pyhist/master/assets/pyhist.png" alt="PyHist Logo" width="450"/>
     </a>
     <br>
 <p>

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open(path.join(this_directory, "README.md"), encoding="utf-8") as f:
 
 setup(
     name="pyhist",
-    version="0.0.4",
+    version="0.0.5",
     author="Javier Guzman",
     author_email="jguzmanfd@gmail.com",
     long_description=long_description,


### PR DESCRIPTION
Due to the rendering of the PyPI web, it's required to set the logo ref as an absolute web URL